### PR TITLE
Add TikTok cookie injection via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The system is configured via environment variables:
 | `CLICKHOUSE_CONN` | ClickHouse connection string | - |
 | `LOG_LEVEL` | Logging verbosity (Trace, Debug, Information, Warning, Error, Critical) | `Debug` |
 | `DEBUG_MODE` | Enable mock event generation | `true` |
+| `TIKTOK_COOKIES` | Optional cookies to send with TikTok requests (format `key=value;`) | - |
 
 Example .env file:
 
@@ -48,6 +49,7 @@ TIKTOK_HOST=username
 CLICKHOUSE_CONN=Host=clickhouse;Port=8123;Database=chakal;User=default;Password=Chakal123!
 LOG_LEVEL=Information
 DEBUG_MODE=false
+TIKTOK_COOKIES=sessionid=abc123; other=val
 ```
 
 ## Running Locally

--- a/env.sample
+++ b/env.sample
@@ -17,4 +17,7 @@ MINIO_STORAGE_AVAILABLE=true
 S3_ENDPOINT=http://192.168.1.230:9100
 S3_ACCESS_KEY=vFpdN5CJGjY5o0jPKVww
 S3_SECRET_KEY=5KpII0ID5oOqFOmSR8G6rd7HJJNBFb9eD1Xb3dTB
-S3_BUCKET=dev-chakal-raw 
+S3_BUCKET=dev-chakal-raw
+
+# Optional cookies for authenticating with TikTok
+TIKTOK_COOKIES=sessionid=abc123; other=val


### PR DESCRIPTION
## Summary
- allow configuring cookies through `TIKTOK_COOKIES` env variable
- update sample environment and docs with new variable

## Testing
- `dotnet test Chakal.IngestSystem.sln -c Release` *(fails: Connection refused)*