### PR TITLE
Improve worker resilience

### DIFF
--- a/Chakal.IngestSystem/BulkWriterWorker.cs
+++ b/Chakal.IngestSystem/BulkWriterWorker.cs
@@ -342,7 +342,7 @@ namespace Chakal.IngestSystem
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error flushing events");
-                throw;
+                // Don't rethrow - keep worker running even if persistence fails
             }
         }
 


### PR DESCRIPTION
## Summary
- reconnect event source when stream ends
- keep BulkWriterWorker running when persistence fails

## Testing
- `dotnet test --no-restore` *(fails: ResolvePackageAssets unable to find fallback package folder)*